### PR TITLE
LOOP-3856: Update to new constructor for TherapySettingsViewModel (#13)

### DIFF
--- a/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift
+++ b/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift
@@ -259,11 +259,13 @@ class OnboardingUICoordinator: UINavigationController, CGMManagerOnboarding, Pum
             therapySettings: therapySettings,
             supportedInsulinModelSettings: supportedInsulinModelSettings,
             pumpSupportedIncrements: { pumpSupportedIncrements },
-            syncPumpSchedule: {
-                { _, _ in
-                    // Since pump isn't set up, this syncing shouldn't do anything
-                    assertionFailure()
-                }
+            syncBasalRateSchedule: { _, _ in
+                // Since pump isn't set up, this syncing shouldn't do anything
+                assertionFailure()
+            },
+            maxTempBasalSavePreflight: { _, completion in
+                // Just call the completion block
+                completion(nil)
             },
             prescription: nil
         ) { [weak self] _, _ in


### PR DESCRIPTION
* LOOP-3856: Update to new constructor for TherapySettingsViewModel

* Fix rename validateTempBasal -> validateMaxTempBasal to make it more clear

* Rename ValidateMaxTempBasal -> MaxTempBasalSavePreflight

* Remove "indirection" in syncBasalRateSchedule and maxTempBasalSavePreflight